### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,6 @@ a list of awesome repos
   - [Sass](https://github.com/HugoGiraudel/awesome-sass)
   - [React](https://github.com/enaqx/awesome-react)
 
-##Contributing
+## Contributing
 
 For contributing, open an [issue](https://github.com/flyhigher139/awesome-collection/issues) and/or a [pull request](https://github.com/flyhigher139/awesome-collection/pulls).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
